### PR TITLE
Changed Content Model to content.type: 'json' and page.type : 'array'…

### DIFF
--- a/api/controllers/ContentController.js
+++ b/api/controllers/ContentController.js
@@ -178,7 +178,7 @@ var findByHost = function (req, res) {
 };
 
 /**
- * Usually used for pages where you can add and remove new content blocks (get sll content blocks by page).
+ * Usually used for pages where you can add and remove new content blocks (get all content blocks by page).
  * TODO rename to find
  */
 var findAll = function (req, res) {
@@ -187,11 +187,14 @@ var findAll = function (req, res) {
     if(err) { return res.serverError(err); }
     query = {
       where: {
-        page: req.param('page'),
         site: conf.name
       },
       sort: 'position'
     };
+
+    if(req.param('page')) {
+      query.where.page=req.param('page');
+    }
 
     if(req.param('type')) {
       query.where.type = req.param('type');

--- a/api/models/Content.js
+++ b/api/models/Content.js
@@ -42,7 +42,7 @@ var attributes = {
     // , unique: true // composite keys not supported: https://github.com/balderdashy/waterline/issues/221
   },
   page: {
-    type: "string"
+    type: "array"
     , required: true
     // , unique: true // composite keys not supported: https://github.com/balderdashy/waterline/issues/221
   },
@@ -59,7 +59,7 @@ var attributes = {
     , unique: true
   },
   content: {
-    type: "string"
+    type: "json"
     , required: false
   },
   position: {


### PR DESCRIPTION
…, to allow more complex types of structured content and contents that can belong to more than one page. Older data should still work with this without causing errors. Also changed the ContentController.findAll method to make the 'page' req.param optional, to make it possible to find all of a specific type, without specifying the page.
